### PR TITLE
Add support for the .scss-lint.yml config file

### DIFF
--- a/lib/linter-scss-lint.coffee
+++ b/lib/linter-scss-lint.coffee
@@ -1,5 +1,7 @@
 linterPath = atom.packages.getLoadedPackage("linter").path
 Linter = require "#{linterPath}/lib/linter"
+findFile = require "#{linterPath}/lib/util"
+
 
 class LinterScssLint extends Linter
   # The syntax that the linter handles. May be a string or
@@ -37,5 +39,9 @@ class LinterScssLint extends Linter
       @cmd = "scss-lint --format=XML --exclude-linter=#{excludedLinters.toString()}"
     else
       @cmd = 'scss-lint --format=XML'
+
+    config = findFile @cwd, ['.scss-lint.yml']
+    if config
+      @cmd += " -c #{config}"
 
 module.exports = LinterScssLint


### PR DESCRIPTION
With this we could remove the `scssLintExcludedLinters` and advise users to work only the `.scss-lint.yml` config, which can not only exclude linters but change how a few of them works.
