### PR TITLE
Parse HTML entity characters in output

### DIFF
--- a/lib/linter-scss-lint.coffee
+++ b/lib/linter-scss-lint.coffee
@@ -44,4 +44,19 @@ class LinterScssLint extends Linter
     if config
       @cmd += " -c #{config}"
 
+  formatMessage: (match) ->
+    map = {
+      quot: '"'
+      amp: '&'
+      lt: '<'
+      gt: '>'
+    }
+
+    message = match.message
+    for key,value of map
+        regex = new RegExp '&' + key + ';', 'g'
+        message = message.replace(regex, value)
+
+    return message
+
 module.exports = LinterScssLint


### PR DESCRIPTION
Currently the output produced contains unparsed HTML entities e.g ```&quot;```

I extended the ```formatMessage``` method and added a very basic html entity parser with room for extension (if needed). I'm sure there's  a better way to do it, possibly using [html-entities](https://github.com/mdevils/node-html-entities)

Before:
![screenshot 2015-02-10 15 26 37](https://cloud.githubusercontent.com/assets/6361200/6129929/a0d9b9aa-b139-11e4-8b80-4174a7b6c400.png)
After:
![screenshot 2015-02-10 15 29 15](https://cloud.githubusercontent.com/assets/6361200/6129932/a68a283a-b139-11e4-9ede-e428fb66cd45.png)
