### PR TITLE
Fix deprecations

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,7 +1,13 @@
 module.exports =
-  configDefaults:
-    scssLintExecutablePath: ''
-    scssLintExcludedLinters: []
+  config:
+    scssLintExecutablePath:
+      type: 'string'
+      default: ''
+    scssLintExcludedLinters:
+      type: 'array'
+      default: []
+      items:
+        type: 'string'
 
   activate: ->
     console.log 'activate linter-scss-lint'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "main": "./lib/init",
   "version": "0.0.14",
   "linter-package": true,
-  "activationEvents": [],
   "description": "Lint SCSS on the fly, using scss-lint",
   "repository": "https://github.com/AtomLinter/linter-scss-lint",
   "license": "MIT",


### PR DESCRIPTION
1. ```Use activationCommands instead of activationEvents in your package.json```
I completely removed it since its not required in this package.

2. ```Use a config schema instead. See the configuration section of https://atom.io/docs/latest/hacking-atom-package-word-count and https://atom.io/docs/api/latest/Config for more details```