### PR TITLE
Use JSON scss-lint formatter, add additionalArguments option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+## master
+* use the JSON scss-lint formatter for better error reporting and scss-lint >=
+  0.39.0 support
+* remove `excludedLinters` option in favor of `additionalArguments` option
+
 ## 0.0.13
 * expose executablePath in settings-view
 
 ## 0.0.12
 * Parse HTML entity characters in output [#19](https://github.com/AtomLinter/linter-scss-lint/pull/19)
- 
+
 ## 0.0.9
 * Add support for the .scss-lint.yml config file

--- a/README.md
+++ b/README.md
@@ -33,10 +33,15 @@ $ apm install linter-scss-lint
 
 ## Settings
 You can configure linter-scss-lint by editing ~/.atom/config.cson (choose Open Your Config in Atom menu):
-```
+```cson
 'linter-scss-lint':
-  'executablePath': null #scss-lint path. run 'which scss-lint' to find the path
-  'excludedLinters': [] # a list of linters to exclude from running. run 'scss-lint --show-linters' to see a list of linters that can be excluded.
+
+  # Optionally specify additional arguments to be passed to `scss-lint`.
+  # Run `scss-lint -h` to see available options.
+  'additionalArguments': null
+
+  # The `scss-lint` path. Run `which scss-lint` to find this path.
+  'executablePath': null
 ```
 
 ## Config file

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,16 +1,13 @@
 module.exports =
   config:
-    executablePath:
-      title: 'Scss-lint Executable Path'
-      description: 'The path where scss-lint is located.'
+    additionalArguments:
+      title: 'Additional Arguments'
       type: 'string'
       default: ''
-    excludedLinters:
-      description: 'A list of linters to exclude from running. run `scss-lint --show-linters` to see a list of linters that can be excluded.'
-      type: 'array'
-      default: []
-      items:
-        type: 'string'
+    executablePath:
+      title: 'Executable Path'
+      type: 'string'
+      default: ''
 
   activate: ->
     console.log 'activate linter-scss-lint'


### PR DESCRIPTION
The `XML` format is not longer supported in the latest `scss-lint` (see [the scss-lint CHANGELOG](https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md#0390)). This change uses the preferred `JSON` formatter. It also swaps the `excludeLinters` option for an `additionalArguments` option, which gives users the freedom to add whatever command line arguments they want, not just `excludeLinters` (`includeLinters`, for example).