### PR TITLE
Change name of gem from scss-lint to scss_lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before using this plugin, you must ensure that `scss-lint` is installed on your 
 
 2. Install [scss-lint](https://github.com/causes/scss-lint) by typing the following in a terminal:
    ```
-   gem install scss-lint
+   gem install scss_lint
    ```
 
 Now you can proceed to install the linter-scss-lint plugin.


### PR DESCRIPTION
The package's offical name is scss_lint with an underscore - installing with this name resolves issues where the linter cannot be found in Atom.