### PR TITLE
Fix linter deprecation notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
   "name": "linter-scss-lint",
   "main": "./lib/init",
-  "version": "1.0.5",
-  "linter-package": true,
+  "version": "1.0.6",
   "description": "Lint SCSS on the fly, using scss-lint",
   "repository": "https://github.com/AtomLinter/linter-scss-lint",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "providedServices": {
+    "linter": {
+      "versions": {
+        "1.0.0": "provideLinter"
+      }
+    }
+  }
 }


### PR DESCRIPTION
This change should fix the deprecation notice that shows up whenever you try to load the linter-scss-lint package.

This has been tested locally on my machine by doing the following:
```sh
git clone git@github.com:Dru89/linter-scss-lint.git
git checkout patch-1
apm uninstall linter-scss-lint
apm install
apm link .
```

And then running atom to make sure it was updated.