### PR TITLE
Add grammar `source.scss`

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -26,7 +26,7 @@ module.exports =
     @subs.dispose()
   provideLinter: ->
     provider =
-      grammarScopes: ['source.css.scss']
+      grammarScopes: ['source.css.scss', 'source.scss']
       scope: 'file'
       lintOnFly: false
       lint: (editor) =>


### PR DESCRIPTION
I was experiencing an issue where the `lint' function in `provider` was not being run on SCSS files when saved.  Adding `source.scss` to grammar scope has cleared it up.