### PR TITLE
Execute `scss-lint` in same dir as file

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -31,8 +31,9 @@ module.exports =
       lintOnFly: yes
       lint: (editor) =>
         filePath = editor.getPath()
+        cwd = path.dirname(filePath)
         tempFile path.basename(filePath), editor.getText(), (tmpFilePath) =>
-          config = findFile path.dirname(filePath), '.scss-lint.yml'
+          config = findFile cwd, '.scss-lint.yml'
           params = [
             tmpFilePath,
             "--format=JSON",
@@ -42,7 +43,7 @@ module.exports =
           throw new TypeError(
             "Error linting #{filePath}: No 'scss-lint' executable specified"
           ) if @executablePath is ''
-          return helpers.exec(@executablePath, params).then (stdout) ->
+          return helpers.exec(@executablePath, params, {cwd}).then (stdout) ->
             lint = try JSON.parse stdout
             throw new TypeError(stdout) unless lint?
             return [] unless lint[tmpFilePath]


### PR DESCRIPTION
Since the content of the editor is currently written to a temporary file, the executable has no idea about where the original file is located.

`scss-lint` is a Ruby gem and often installed in a specific version for a given project, and might vary from project to project, with different, incompatible configurations.

It's trivial to write a wrapper for `scss-lint` that executes the correct version, perhaps using `bundler` and a specific version of Ruby if you use a version manager. But for this to work, we must be able to determine the original location of the project.