### PR TITLE
fixes rvm wrapper command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Consult rvm docs for further info not covered in this README - https://rvm.io/
 This will create a wrapper just for atom using your current ruby version:
 
 ```bash
-$ rvm wrapper current atom scss_lint
+$ rvm wrapper current atom scss-lint
 ```
 
 Then in `linter-scss-lint` set `executablePath` to `/path/to/rvm/bin/atom_scss-lint`


### PR DESCRIPTION
Using the previous command would return:

```bash

Could not find file 'scss_lint' nor '/.rvm/wrappers/ruby-2.2.2/scss_lint'.

```

I think the wrapper command expects the bin name and not the gem's name. 
