### PR TITLE
Provide linter name

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -35,6 +35,7 @@ module.exports =
 
   provideLinter: ->
     provider =
+      name: 'scss-lint'
       grammarScopes: ['source.css.scss', 'source.scss']
       scope: 'file'
       lintOnFly: yes


### PR DESCRIPTION
This prevents the linter from being labeled as "Unnamed linter" in editor.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-scss-lint/115)
<!-- Reviewable:end -->
