### PR TITLE
Pass file contents to linter via STDIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Before using this plugin, you must ensure that `scss-lint` is installed on your 
    ```
    gem install scss_lint
    ```
+   **IMPORTANT**: Since v3.0.0, this package requires version 0.43.0 of scss-lint.
 
 Now you can proceed to install the linter-scss-lint plugin.
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -49,12 +49,12 @@ module.exports =
         filePath = editor.getPath()
         fileText = editor.getText()
 
-        return [] if fileText.length is 0
+        return Promise.resolve([]) if fileText.length is 0
 
         config = find filePath, '.scss-lint.yml'
         relativeFilePath = @getRelativeFilePath(filePath, config)
 
-        return [] if @disableOnNoConfig and not config
+        return Promise.resolve([]) if @disableOnNoConfig and not config
 
         cwd = path.dirname(filePath)
         params = [
@@ -78,13 +78,14 @@ module.exports =
           .then (contents) ->
             return [] unless contents[relativeFilePath]
             return contents[relativeFilePath].map (msg) ->
+              badge = "<span class='badge badge-flexible scss-lint'>#{msg.linter}</span> " if msg.linter
+
               # Atom expects ranges to be 0-based
               line = (msg.line or 1) - 1
               col = (msg.column or 1) - 1
 
               type: msg.severity or 'error',
-              html: "<span class='badge badge-flexible scss-lint'>#{msg.linter or ''}</span>" +
-                    "#{msg.reason or 'Unknown Error'}",
+              html: "#{badge or ''}#{msg.reason or 'Unknown Error'}",
               filePath: filePath,
               range: [[line, col], [line, col + (msg.length or 0)]]
           .catch (error) ->

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -69,7 +69,7 @@ module.exports =
             regex = /^invalid option: --stdin-file-path\=/g
             if regex.exec(output)
               atom.notifications.addError('You are using an old version of scss-lint', {
-                detail: "Please upgrade your version of scss-lint.\nCheck the README for further information.",
+                detail: 'Please upgrade your version of scss-lint.\nCheck the README for further information.',
                 dismissable: true
               })
               return {}
@@ -83,7 +83,8 @@ module.exports =
               col = (msg.column or 1) - 1
 
               type: msg.severity or 'error',
-              html: "<span class='badge badge-flexible scss-lint'>#{msg.linter or ''}</span> #{msg.reason or 'Unknown Error'}",
+              html: "<span class='badge badge-flexible scss-lint'>#{msg.linter or ''}</span>" +
+                    "#{msg.reason or 'Unknown Error'}",
               filePath: filePath,
               range: [[line, col], [line, col + (msg.length or 0)]]
           .catch (error) ->

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,5 +1,5 @@
 {CompositeDisposable} = require 'atom'
-{find, exec, tempFile} = helpers = require 'atom-linter'
+{find, exec} = helpers = require 'atom-linter'
 path = require 'path'
 
 module.exports =
@@ -41,29 +41,30 @@ module.exports =
       lintOnFly: yes
       lint: (editor) =>
         filePath = editor.getPath()
+        fileText = editor.getText()
+
         cwd = path.dirname(filePath)
 
         config = find cwd, '.scss-lint.yml'
 
         return [] if @disableOnNoConfig and not config
 
-        tempFile path.basename(filePath), editor.getText(), (tmpFilePath) =>
-          params = [
-            tmpFilePath,
-            '--format=JSON',
-            if config? then "--config=#{config}",
-            @additionalArguments.split(' ')...
-          ].filter((e) -> e)
-          return helpers.exec(@executablePath, params, {cwd}).then (stdout) ->
-            lint = try JSON.parse stdout
-            throw new TypeError(stdout) unless lint?
-            return [] unless lint[tmpFilePath]
-            return lint[tmpFilePath].map (msg) ->
-              line = (msg.line or 1) - 1
-              col = (msg.column or 1) - 1
+        params = [
+          "--stdin-file-path=#{filePath}",
+          '--format=JSON',
+          if config? then "--config=#{config}",
+          @additionalArguments.split(' ')...
+        ].filter((e) -> e)
+        return helpers.exec(@executablePath, params, {stdin: fileText, cwd}).then (stdout) ->
+          lint = try JSON.parse stdout
+          throw new TypeError(stdout) unless lint?
+          return [] unless lint[filePath]
+          return lint[filePath].map (msg) ->
+            line = (msg.line or 1) - 1
+            col = (msg.column or 1) - 1
 
-              type: msg.severity or 'error',
-              text: (msg.reason or 'Unknown Error') +
-                (if msg.linter then " (#{msg.linter})" else ''),
-              filePath: filePath,
-              range: [[line, col], [line, col + (msg.length or 0)]]
+            type: msg.severity or 'error',
+            text: (msg.reason or 'Unknown Error') +
+              (if msg.linter then " (#{msg.linter})" else ''),
+            filePath: filePath,
+            range: [[line, col], [line, col + (msg.length or 0)]]

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -69,7 +69,7 @@ module.exports =
             try
               return JSON.parse(output)
             catch error
-              regex = /^invalid option: --stdin-file-path\=/g
+              regex = /^invalid option: --stdin-file-path\=/
               if regex.exec(output)
                 atom.notifications.addError('You are using an old version of scss-lint', {
                   detail: 'Please upgrade your version of scss-lint.\nCheck the README for further information.',
@@ -79,7 +79,7 @@ module.exports =
               else
                 console.error('[Linter-SCSS-Lint]', error, output)
                 atom.notifications.addError('[Linter-SCSS-Lint]', {
-                  detail: 'SCSS-Lint returned an invalid response, check your console for more info',
+                  detail: 'SCSS-Lint returned an invalid response, check your console for more info.',
                   dismissable: true
                 })
                 return {}
@@ -96,3 +96,16 @@ module.exports =
               html: "#{badge or ''}#{msg.reason or 'Unknown Error'}",
               filePath: filePath,
               range: [[line, col], [line, col + (msg.length or 0)]]
+          .catch (error) ->
+            if error.code is 'ENOENT' and error.syscall.indexOf('spawn') is 0
+              command = path.basename(error.path)
+              atom.notifications.addError("Failed to spawn command `#{command}`.", {
+                detail: "Make sure `#{command}` is installed and on your PATH.",
+                dismissable: true
+              })
+            else
+              atom.notifications.addError('[Linter-SCSS-Lint]', {
+                detail: error.message,
+                dismissable: true
+              })
+            return []

--- a/spec/fixtures/invalid.scss
+++ b/spec/fixtures/invalid.scss
@@ -1,0 +1,3 @@
+body {
+  background-color: red;
+}

--- a/spec/linter-scss-lint-spec.js
+++ b/spec/linter-scss-lint-spec.js
@@ -4,8 +4,10 @@ import * as path from 'path';
 
 const lint = require(path.join('..', 'lib', 'init')).provideLinter().lint;
 
-const goodPath = path.join(__dirname, 'fixtures', 'good.scss');
 const badPath = path.join(__dirname, 'fixtures', 'bad.scss');
+const emptyPath = path.join(__dirname, 'fixtures', 'empty.scss');
+const goodPath = path.join(__dirname, 'fixtures', 'good.scss');
+const invalidPath = path.join(__dirname, 'fixtures', 'invalid.scss');
 
 describe('The scss_lint provider for Linter', () => {
   beforeEach(() => {
@@ -18,8 +20,17 @@ describe('The scss_lint provider for Linter', () => {
     });
   });
 
-  describe('checks bad.scss and', () => {
+  it('should be in the packages list', () =>
+    expect(atom.packages.isPackageLoaded('linter-scss-lint')).toEqual(true)
+  );
+
+  it('should be an active package', () =>
+    expect(atom.packages.isPackageActive('linter-scss-lint')).toEqual(true)
+  );
+
+  describe('shows errors in a file with errors', () => {
     let editor = null;
+
     beforeEach(() => {
       waitsForPromise(() =>
         atom.workspace.open(badPath).then(openEditor => { editor = openEditor; })
@@ -35,21 +46,71 @@ describe('The scss_lint provider for Linter', () => {
     });
 
     it('verifies the first message', () => {
-      const messageText = 'Syntax Error: Invalid CSS after "body {": expected "}", was ""';
+      const messageHtml = 'Syntax Error: Invalid CSS after "body {": expected "}", was ""';
+
       waitsForPromise(() =>
         lint(editor).then(messages => {
           expect(messages[0].type).toBeDefined();
           expect(messages[0].type).toEqual('error');
-          expect(messages[0].text).toBeDefined();
-          expect(messages[0].text).toEqual(messageText);
+          expect(messages[0].html).toBeDefined();
+          expect(messages[0].html).toEqual(messageHtml);
+          expect(messages[0].text).not.toBeDefined();
           expect(messages[0].filePath).toBeDefined();
-          expect(messages[0].filePath).toMatch(/.+bad\.scss$/);
+          expect(messages[0].filePath).toEqual(badPath);
           expect(messages[0].range).toBeDefined();
           expect(messages[0].range.length).toEqual(2);
           expect(messages[0].range).toEqual([[1, 0], [1, 1]]);
         })
       );
     });
+  });
+
+  describe('shows errors in a file with warnings', () => {
+    let editor = null;
+
+    beforeEach(() => {
+      waitsForPromise(() =>
+        atom.workspace.open(invalidPath).then(openEditor => { editor = openEditor; })
+      );
+    });
+
+    it('finds at least one message', () => {
+      waitsForPromise(() =>
+        lint(editor).then(messages =>
+          expect(messages.length).toBeGreaterThan(0)
+        )
+      );
+    });
+
+    it('verifies the first message', () => {
+      const messageHtml = "<span class='badge badge-flexible scss-lint'>ColorKeyword</span> " +
+                          'Color `red` should be written in hexadecimal form as `#ff0000`';
+
+      waitsForPromise(() =>
+        lint(editor).then(messages => {
+          expect(messages[0].type).toBeDefined();
+          expect(messages[0].type).toEqual('warning');
+          expect(messages[0].html).toBeDefined();
+          expect(messages[0].html).toEqual(messageHtml);
+          expect(messages[0].text).not.toBeDefined();
+          expect(messages[0].filePath).toBeDefined();
+          expect(messages[0].filePath).toEqual(invalidPath);
+          expect(messages[0].range).toBeDefined();
+          expect(messages[0].range.length).toEqual(2);
+          expect(messages[0].range).toEqual([[1, 20], [1, 23]]);
+        })
+      );
+    });
+  });
+
+  it('finds nothing wrong with an empty file', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(emptyPath).then(editor =>
+        lint(editor).then(messages =>
+          expect(messages.length).toEqual(0)
+        )
+      )
+    );
   });
 
   it('finds nothing wrong with a valid file', () => {


### PR DESCRIPTION
With the release of scss-lint v0.43.0, you can now lint files via STDIN. This PR passes the file contents directly to scss-lint, rather than generating a temp file.

Is there anything needed doing to let users know that v0.43.0 onwards is required?

Fixes #103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-scss-lint/136)
<!-- Reviewable:end -->
