### PR TITLE
Pass an absolute file path to STDIN

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -33,12 +33,6 @@ module.exports =
   deactivate: ->
     @subs.dispose()
 
-  getRelativeFilePath: (filePath, configPath) ->
-    if configPath
-      path.relative(path.dirname(configPath), filePath)
-    else
-      filePath
-
   provideLinter: ->
     provider =
       name: 'scss-lint'
@@ -52,13 +46,12 @@ module.exports =
         return Promise.resolve([]) if fileText.length is 0
 
         config = find filePath, '.scss-lint.yml'
-        relativeFilePath = @getRelativeFilePath(filePath, config)
 
         return Promise.resolve([]) if @disableOnNoConfig and not config
 
         cwd = path.dirname(filePath)
         params = [
-          "--stdin-file-path=#{relativeFilePath}",
+          "--stdin-file-path=#{filePath}",
           '--format=JSON',
           if config? then "--config=#{config}",
           @additionalArguments.split(' ')...
@@ -84,8 +77,8 @@ module.exports =
                 })
                 return {}
           .then (contents) ->
-            return [] unless contents[relativeFilePath]
-            return contents[relativeFilePath].map (msg) ->
+            return [] unless contents[filePath]
+            return contents[filePath].map (msg) ->
               badge = "<span class='badge badge-flexible scss-lint'>#{msg.linter}</span> " if msg.linter
 
               # Atom expects ranges to be 0-based


### PR DESCRIPTION
Pass an absolute path to STDIN, instead of a relative (to the .scss-lint.yml) file path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-scss-lint/148)
<!-- Reviewable:end -->
