### PR TITLE
Remove redundant `allowEmptyStderr` option

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -51,7 +51,6 @@ module.exports =
 
         cwd = path.dirname(filePath)
         options = {
-          allowEmptyStderr: true,
           cwd,
           ignoreExitCode: true,
           stdin: fileText,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-scss-lint/153)
<!-- Reviewable:end -->
