### PR TITLE
Config Name Option

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -16,6 +16,10 @@ module.exports =
       title: 'Executable Path'
       type: 'string'
       default: 'scss-lint'
+    configName:
+      title: 'Config Name'
+      type: 'string'
+      default: '.scss-lint.yml'
 
   activate: ->
     require('atom-package-deps').install('linter-scss-lint')
@@ -29,6 +33,9 @@ module.exports =
     @subs.add atom.config.observe 'linter-scss-lint.disableWhenNoConfigFileInPath',
       (disableOnNoConfig) =>
         @disableOnNoConfig = disableOnNoConfig
+    @subs.add atom.config.observe 'linter-scss-lint.configName',
+      (configName) =>
+        @configName = configName
 
   deactivate: ->
     @subs.dispose()
@@ -51,7 +58,7 @@ module.exports =
 
         return Promise.resolve([]) if fileText.length is 0
 
-        config = find filePath, '.scss-lint.yml'
+        config = find filePath, @configName
         relativeFilePath = @getRelativeFilePath(filePath, config)
 
         return Promise.resolve([]) if @disableOnNoConfig and not config


### PR DESCRIPTION
Unfortunately my team uses a different name for their scss-lint config file. Duplicating their config file and renaming it to `.scss-lint.yml` makes little sense to me.

- Adding a field where one can enter a different name for their scss-lint config

The default for this field remains set to `.scss-lint.yml`, so current users shouldn't have to change a thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-scss-lint/168)
<!-- Reviewable:end -->
