### PR TITLE
Allow disabling of execution timeout

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -10,6 +10,7 @@ let executablePath;
 let additionalArguments;
 let disableOnNoConfig;
 let configName;
+let disableTimeout;
 
 export default {
   activate() {
@@ -35,6 +36,11 @@ export default {
     this.subs.add(
       atom.config.observe('linter-scss-lint.configName', (value) => {
         configName = value;
+      }),
+    );
+    this.subs.add(
+      atom.config.observe('linter-scss-lint.disableTimeout', (value) => {
+        disableTimeout = value;
       }),
     );
   },
@@ -76,6 +82,9 @@ export default {
           stdin: fileText,
           ignoreExitCode: true,
         };
+        if (disableTimeout) {
+          options.timeout = Infinity;
+        }
 
         const params = [
           `--stdin-file-path=${relativeFilePath}`,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
       "title": "Config Name",
       "type": "string",
       "default": ".scss-lint.yml"
+    },
+    "disableTimeout": {
+      "title": "Disable Execution Timeout",
+      "type": "boolean",
+      "default": false,
+      "description": "Exection of `scss-lint` times out after 10 seconds by default, this disables that timeout."
     }
   },
   "scripts": {


### PR DESCRIPTION
Apparently `scss-lint` can take over 10s to run on large files, allow
users to disable the timeout if they are running on files that large.

Fixes #176.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-scss-lint/203)
<!-- Reviewable:end -->
