### PR TITLE
Upgrade to linter API v2

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -116,11 +116,6 @@ export default {
         }
 
         return (contents[relativeFilePath] || []).map((msg) => {
-          let badge;
-          if (msg.linter) {
-            badge = `<span class='badge badge-flexible scss-lint'>${msg.linter}</span> `;
-          }
-
           // Atom expects ranges to be 0-based
           const line = (msg.line || 1) - 1;
           const col = (msg.column || 1) - 1;
@@ -136,10 +131,12 @@ export default {
           }
 
           return {
-            type: msg.severity || 'error',
-            html: `${badge || ''}${msg.reason || 'Unknown Error'}`,
-            filePath,
-            range,
+            severity: msg.severity || 'error',
+            excerpt: `${`${msg.linter}: ` || ''}${msg.reason || 'Unknown Error'}`,
+            location: {
+              file: filePath,
+              position: range,
+            },
           };
         });
       },

--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
     "jasmine-fix": "^1.3.0"
   },
   "package-deps": [
-    "linter"
+    "linter:2.0.0"
   ],
   "providedServices": {
     "linter": {
       "versions": {
-        "1.1.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },

--- a/spec/linter-scss-lint-spec.js
+++ b/spec/linter-scss-lint-spec.js
@@ -31,26 +31,27 @@ describe('The scss_lint provider for Linter', () => {
   it('shows messages in a file with errors', async () => {
     const editor = await atom.workspace.open(badPath);
     const messages = await lint(editor);
-    const messageHtml = 'Syntax Error: Invalid CSS after "body {": expected "}", was ""';
+    const messageHtml = 'Syntax: ' +
+      'Syntax Error: Invalid CSS after "body {": expected "}", was ""';
 
-    expect(messages[0].type).toBe('error');
-    expect(messages[0].html).toBe(messageHtml);
-    expect(messages[0].text).not.toBeDefined();
-    expect(messages[0].filePath).toBe(badPath);
-    expect(messages[0].range).toEqual([[1, 0], [1, 1]]);
+    expect(messages[0].severity).toBe('error');
+    expect(messages[0].excerpt).toBe(messageHtml);
+    expect(messages[0].description).not.toBeDefined();
+    expect(messages[0].location.file).toBe(badPath);
+    expect(messages[0].location.position).toEqual([[1, 0], [1, 1]]);
   });
 
   it('shows messages in a file with warnings', async () => {
     const editor = await atom.workspace.open(invalidPath);
     const messages = await lint(editor);
-    const messageHtml = "<span class='badge badge-flexible scss-lint'>ColorKeyword</span> " +
-                        'Color `red` should be written in hexadecimal form as `#ff0000`';
+    const messageHtml = 'ColorKeyword: ' +
+      'Color `red` should be written in hexadecimal form as `#ff0000`';
 
-    expect(messages[0].type).toBe('warning');
-    expect(messages[0].html).toBe(messageHtml);
-    expect(messages[0].text).not.toBeDefined();
-    expect(messages[0].filePath).toBe(invalidPath);
-    expect(messages[0].range).toEqual([[1, 20], [1, 23]]);
+    expect(messages[0].severity).toBe('warning');
+    expect(messages[0].excerpt).toBe(messageHtml);
+    expect(messages[0].description).not.toBeDefined();
+    expect(messages[0].location.file).toBe(invalidPath);
+    expect(messages[0].location.position).toEqual([[1, 20], [1, 23]]);
   });
 
   it('finds nothing wrong with an empty file', async () => {


### PR DESCRIPTION
Upgrade this provider to the v2 linter API so it can continue to work with newer versions of `linter`.

Fixes #224.