### PR TITLE
lintsOnChange wasn't defined

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -52,7 +52,7 @@ export default {
       name: 'scss-lint',
       grammarScopes: ['source.css.scss', 'source.scss'],
       scope: 'file',
-      lintOnFly: true,
+      lintsOnChange: true,
       lint: async (editor) => {
         const filePath = editor.getPath();
         const fileText = editor.getText();


### PR DESCRIPTION
Changing the old `lintOnFly` to `lintsOnChange` was missed as part of #225.

Fixes #226.